### PR TITLE
Latest COLORFUL creation

### DIFF
--- a/Foo_textdisplay_Updated
+++ b/Foo_textdisplay_Updated
@@ -1,0 +1,15 @@
+[$caps2(
+[>>>[%title%]<<<$crlf()]
+[[>%artist%<]$crlf() ]
+$crlf() 
+[$info(channel_mode)'CH - ']%channels%[' In '$info(MP3_STEREO_MODE)]$crlf()
+[%samplerate% Hz][ $info(bitspersample)-Bit]  '('%filesize_natural%')'$crlf()
+[$info(encoding)][' | '$info(codec)[' | '$info(codec_profile)]][ '|' $info(bitrate) Kpbs$crlf()]
+[Encoder: [$left(%__tool%,23)' '$crlf()]]
+[Tags: %__tagtype%$crlf() ]$crlf()
+<<[Last Played: '['$date(%last_played%)']' TOTAL: %play_count%]>>$crlf()
+>>>$progress2(%_time_elapsed_seconds%,%_time_total_seconds%,24,$char(9635),$char(9633))<<<$crlf()
+>>>[$pad('Position:',20)[$pad(%playback_time%,5)]<<<$crlf()]
+>>[$pad('Remaining:',18)[$pad(%playback_time_remaining%,5)<<$crlf()]]
+<[$pad('Total:',22)$pad(%length%,5)]>
+)]


### PR DESCRIPTION


[foo_textdisplay-1.1_beta_1-20110529.zip](https://github.com/SPIKEYPUP/Snippets/files/916904/foo_textdisplay-1.1_beta_1-20110529.zip)

I wasn't aware there was a much newer component out. There are some tradeoffs however:

1. This updated component adds color tags by way of Foobar UI "<obj>" ">obj<" brightening and dimming tags, 3 levels in each direction.
a. For Example To ">>>BrightenMAX<<<", to "<<<DimMAX>>>"
b. They can be used as part of conditional and logic statements, but with caution, there is something strange about the way this version handles these codes, they need to be followed or preceded with a character space (spacebar) or snugged right into another string, or else the plugin prints the literal text, this is probably by design as it was mentioned in the prior versions that CRLF, TAB, and some others wouldn't work, they did...now they don't.
c. Caveat Emptor!  If you love your $CRLF() and $TAB() action, then maybe stick with the older one?  You have to mind the requirement for the LF/TAB etc. to be within a conditional bracket, or similar, it takes trial and error, I don't understand the new syntax as of yet, it might be in the docs, but come on... who RTFM?  OMG you're reading this... I guess people do RTFM.  =O
2. This edition also allows you to use a variety of call functions, cmd functions, and hyperlinking intra and extra system so you could perse:
a. Have a link to google for that artist or Discogs, Etc. come up when it is playing
b. Have a Hyperlink to the file location within explorer or on a command line
c. The docs for the plugin contain the relevant commands and functions that you can bind, check it out!