### PR TITLE
Update Foo_textdisplay_Updated

### DIFF
--- a/Foo_textdisplay_Updated
+++ b/Foo_textdisplay_Updated
@@ -1,15 +1,12 @@
-[$caps2(
-[>>>[%title%]<<<$crlf()]
-[[>%artist%<]$crlf() ]
-$crlf() 
-[$info(channel_mode)'CH - ']%channels%[' In '$info(MP3_STEREO_MODE)]$crlf()
-[%samplerate% Hz][ $info(bitspersample)-Bit]  '('%filesize_natural%')'$crlf()
+$caps2([$insert(>>>%title%<<<,$crlf(),$sub($strchr(%title%,'('),1))$crlf()
+[>>%artist%<<$crlf() ]$crlf()
+[$info(channels)'CH - ']In %channels%[' Using '$info(MP3_STEREO_MODE)]$crlf()
+[%samplerate% Hz |][ $info(bitspersample)-Bit  | ]'('%filesize_natural%')'$crlf()
 [$info(encoding)][' | '$info(codec)[' | '$info(codec_profile)]][ '|' $info(bitrate) Kpbs$crlf()]
-[Encoder: [$left(%__tool%,23)' '$crlf()]]
+[Encoder: [$left(%__tool%,23)' '$crlf()]]$crlf() 
 [Tags: %__tagtype%$crlf() ]$crlf()
-<<[Last Played: '['$date(%last_played%)']' TOTAL: %play_count%]>>$crlf()
->>>$progress2(%_time_elapsed_seconds%,%_time_total_seconds%,24,$char(9635),$char(9633))<<<$crlf()
->>>[$pad('Position:',20)[$pad(%playback_time%,5)]<<<$crlf()]
->>[$pad('Remaining:',18)[$pad(%playback_time_remaining%,5)<<$crlf()]]
-<[$pad('Total:',22)$pad(%length%,5)]>
-)]
+[<<[Last Play: '['$date(%last_played%)']'] [TOTAL: %play_count%]>>]$crlf()
+[>>>$progress2(%_time_elapsed_seconds%,%_time_total_seconds%,25,$char(9635),$char(9633))<<<$crlf() ]$crlf()
+[>>>$pad('Position:',20)$pad(%playback_time%,5)]<<<]$crlf()
+>>[$pad('Total:',22)$pad(%length%,5)]<<$crlf()
+[$pad('Remaining:',18)$pad(%playback_time_remaining%,5)])


### PR DESCRIPTION
Latest iteration, I don't know if I would call this cleaned up.  I have to reparse it by hand again, I'm getting strange errors when trying to brighten/dim text, there might be an errant empty space somewhere or something.  Although after playing around with this for a couple hours, it might be a bug in the beta of the component itself, in which case I will need to see if I can get into the source code on the project.  I don't think it is GIT.

1. Added a string search to insert a CRLF after the first '(' found in %title%, this will separate out the parenthesis content from the first section of the title, allowing better format flow instead of a long running line.
2. Adjusted line positions and colors (where possible, new bug may have been found in source component causing formatting problems)
3. Added pads where needed.
4. added vertical pipe/separator '|' to various subsections to improve readability of output.
5. Changed channels function, will now display nCH - In <mode> Using <MP3 MODE>  , for example:
a.   2CH - In Stereo - Using Joint Stereo
b . 2CH - In Stereo
c. 6CH - In 6CH  (I need to create a filtered statement to insert the word "Multi-CH' or 'Surround'... ToDO LIST!